### PR TITLE
Try Basic auth instead of query params

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 93C4A3FD7BB9C367 16
 WORKDIR /usr/bin
 
 RUN wget https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-for-it.sh \
-  && echo '3f3790f899f53d1a10947f0b992b122a358ffa34997d8c0fe126a02bba806917  wait-for-it.sh' | sha256sum -c - \
+  && echo '2ea7475e07674e4f6c1093b4ad6b0d8cbbc6f9c65c73902fb70861aa66a6fbc0  wait-for-it.sh' | sha256sum -c - \
   && chmod a+x wait-for-it.sh
 
 RUN mkdir -p /root/.ssh

--- a/app/models/concerns/api_client.rb
+++ b/app/models/concerns/api_client.rb
@@ -25,9 +25,9 @@ module ApiClient
 
   def oauth_client_api
     @oauth_client_api ||= Octokit::Client.new(
-      :client_id     => github_client_id,
-      :client_secret => github_client_secret,
-      :api_endpoint  => github_api_endpoint
+      :login        => github_client_id,
+      :password     => github_client_secret,
+      :api_endpoint => github_api_endpoint
     )
   end
 end


### PR DESCRIPTION
Let's try to change auth type because passing client id and token in query params is deprecated
https://developer.github.com/changes/2019-11-05-deprecated-passwords-and-authorizations-api/#authenticating-using-query-parameters

We use **latest** tag for heaven docker image, so I want to build separate tag and deploy it (to make rollback easier in case of any problems). After that, I'll tag new image as **latest**.