### PR TITLE
Bump nodejs to 12.x

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update --quiet=2 \
 RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 1646B01B86E50310 \
   && echo "deb http://dl.yarnpkg.com/debian/ stable main" > /etc/apt/sources.list.d/yarn.list \
   && apt-get update --quiet=2 \
-  && apt-get install --assume-yes --no-install-recommends curl nodejs=8.* yarn \
+  && apt-get install --assume-yes --no-install-recommends curl nodejs=12.* yarn \
   && apt-get autoremove --assume-yes \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
8.x is already quite old and started causing certain GHA tasks to fail with
```
The engine "node" is incompatible with this module. Expected version "^12.18.2". Got "8.10.0"
```

There's a bit of a questionmark here on whether we have something else that would still rely on these containers having nodejs 8.x.